### PR TITLE
NextJs options added.

### DIFF
--- a/.changeset/rare-pets-lie.md
+++ b/.changeset/rare-pets-lie.md
@@ -1,0 +1,5 @@
+---
+"openapi-fetch": patch
+---
+
+Fixed fetch options used by NextJs to be passed to fetch.

--- a/packages/openapi-fetch/examples/nextjs/app/page.tsx
+++ b/packages/openapi-fetch/examples/nextjs/app/page.tsx
@@ -6,6 +6,10 @@ async function getFact() {
     params: {
       query: { max_length: 500 },
     },
+    next: {
+      revalidate: 10,
+      tags: ["cat"],
+    }
   });
 }
 

--- a/packages/openapi-fetch/src/index.d.ts
+++ b/packages/openapi-fetch/src/index.d.ts
@@ -108,7 +108,10 @@ export type RequestBodyOption<T> =
       : { body: OperationRequestBodyContent<T> };
 
 export type FetchOptions<T> = RequestOptions<T> &
-  Omit<RequestInit, "body" | "headers">;
+  Omit<RequestInit, "body" | "headers"> & NextJsFetchOptions;
+
+export type NextJsFetchOptions = 
+  {next?: {revalidate?: false | 0 | number, tags?: string[]}};
 
 /** This type helper makes the 2nd function param required if params/requestBody are required; otherwise, optional */
 export type MaybeOptionalInit<P extends {}, M extends keyof P> =

--- a/packages/openapi-fetch/src/index.js
+++ b/packages/openapi-fetch/src/index.js
@@ -98,7 +98,7 @@ export default function createClient(clientOptions) {
     }
 
     // fetch!
-    let response = await fetch(request);
+    let response = await fetch(request, init.next ? {next: init.next} : undefined);
 
     // middleware (response)
     // execute in reverse-array order (first priority gets last transform)


### PR DESCRIPTION
## Changes
NextJs uses fetch's options to pass information about caching. These were removed by openapi-fetch.

https://github.com/drwpow/openapi-typescript/issues/1569#issuecomment-1966999115

## Checklist

- [x] Unit tests updated
- [x] `docs/` updated (if necessary)
- [x] `pnpm run update:examples` run (only applicable for openapi-typescript)
